### PR TITLE
Fixing Invalid value of 'author' key (expected list, got str)

### DIFF
--- a/matchmaking/info.json
+++ b/matchmaking/info.json
@@ -1,5 +1,7 @@
 {
-    "author" : "Obliviatum",
+    "author": [
+        "Obliviatum (Obliviatum#1892)"
+    ],
     "description" : "This cog allows members to ping other members for a certain game & @role.",
     "disabled" : false,
     "end_user_data_statement" : "This cog does not persistently store data or metadata about users.",


### PR DESCRIPTION
Issue raised in https://github.com/Obliviatum/ObliCogs/issues/3 

This fixes this error